### PR TITLE
fix: Remove references to non-existent basic_math_types dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@
 resolver = "2"
 
 # Include all tool directories as workspace members
+
 members = [
     "tools/basic_math/add",
     "tools/basic_math/distance-two-d",
@@ -17,7 +18,6 @@ members = [
     "tools/basic_math/sqrt",
     "tools/basic_math/square",
     "tools/basic_math/subtract",
-    "shared/basic_math_types",
     "tools/datetime/current_datetime",
     "tools/encoding/base64_decoder",
     "tools/encoding/base64_encoder",

--- a/tools/basic_math/multiply/Cargo.toml
+++ b/tools/basic_math/multiply/Cargo.toml
@@ -16,5 +16,4 @@ ftl-sdk = { version = "0.2.3", features = ["macros"], optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 schemars = "0.8"
-basic_math_types = { path = "../../../shared/basic_math_types" }
 spin-sdk = { version = "4.0", optional = true }

--- a/tools/basic_math/subtract/Cargo.toml
+++ b/tools/basic_math/subtract/Cargo.toml
@@ -16,5 +16,4 @@ ftl-sdk = { version = "0.2.3", features = ["macros"], optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 schemars = "0.8"
-basic_math_types = { path = "../../../shared/basic_math_types" }
 spin-sdk = { version = "4.0", optional = true }


### PR DESCRIPTION
- Remove basic_math_types from multiply tool Cargo.toml
- Remove basic_math_types from subtract tool Cargo.toml
- Fixes cargo fmt --all -- --check failure